### PR TITLE
Update API URLs from localhost to api.boozang.com

### DIFF
--- a/src/components/forms/FormFill.js
+++ b/src/components/forms/FormFill.js
@@ -22,7 +22,7 @@ function FormFill() {
     email: "",
     password: "",
   });
-  const usersUrl = "//localhost:9000/users/";
+  const usersUrl = "http://api.boozang.com/users/";
 
   const getUsers = async () => {
     const usersFromServer = await getData(usersUrl);

--- a/src/components/lists/AddTodo.js
+++ b/src/components/lists/AddTodo.js
@@ -6,7 +6,7 @@ const AddTodo = ({ addTodo, todos }) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const totalTodos = todos;
-  const todosUrl = "//localhost:9000/todos/";
+  const todosUrl = "http://api.boozang.com/todos/";
 
   //add Todo in db
   const handleSubmit = async (e) => {

--- a/src/components/lists/SortedList.js
+++ b/src/components/lists/SortedList.js
@@ -15,7 +15,7 @@ const SortedList = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const todosUrl = "//localhost:9000/todos/";
+  const todosUrl = "http://api.boozang.com/todos/";
   useEffect(() => {
     const getTodos = async () => {
       const todosFromServer = await getData(todosUrl);

--- a/src/components/lists/UnsortedList.js
+++ b/src/components/lists/UnsortedList.js
@@ -14,7 +14,7 @@ const UnsortedList = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const todosUrl = "//localhost:9000/todos";
+  const todosUrl = "http://api.boozang.com/todos";
 
   useEffect(() => {
     const getTodos = async () => {
@@ -34,7 +34,7 @@ const UnsortedList = () => {
   //delete Todo in db and Gui
   const handleDelete = async (id) => {
     //id= argument in handleDelete() from TodoList component
-    //fetch(`//localhost:9000/todos/${id}`
+    //fetch(`http://api.boozang.com/todos/${id}`
     await deleteData(todosUrl, id);
     //setting Gui state
     setTodos(

--- a/src/components/lists/catList/AddCat.js
+++ b/src/components/lists/catList/AddCat.js
@@ -12,7 +12,7 @@ const AddCat = () => {
     inOrOutside: "",
   });
 
-  const catsUrl = "//localhost:9000/cats/";
+  const catsUrl = "http://api.boozang.com/cats/";
   const history = useHistory();
 
   const handleChange = (e) => {

--- a/src/components/lists/catList/CatDetails.js
+++ b/src/components/lists/catList/CatDetails.js
@@ -17,7 +17,7 @@ const CatDetails = () => {
   });
 
   const { cat_id } = useParams();
-  const catsUrl = "//localhost:9000/cats/";
+  const catsUrl = "http://api.boozang.com/cats/";
   const singleCatUrl = catsUrl + cat_id;
   const history = useHistory();
 
@@ -62,10 +62,10 @@ const CatDetails = () => {
       inOrOutside: newValues.inOrOutside,
     };
     //PUT request...send update
-    const updatedCatFromServer = await updateData(singleCatUrl, updatedCat);
+    const cupdatedCatFromServer = await updateData(singleCatUrl, updatedCat);
     // console.log("cupdatedCatFromServer", cupdatedCatFromServer);
 
-    if (updatedCatFromServer) {
+    if (cupdatedCatFromServer) {
       //redirecting so do not have to set gui state
       history.push("/catshelter");
     } else {

--- a/src/components/lists/catList/CatShelter.js
+++ b/src/components/lists/catList/CatShelter.js
@@ -15,7 +15,7 @@ const CatShelter = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const catsUrl = "//localhost:9000/cats";
+  const catsUrl = "http://api.boozang.com/cats";
 
   useEffect(() => {
     const getCats = async () => {

--- a/src/components/text/DbInfo.js
+++ b/src/components/text/DbInfo.js
@@ -1,6 +1,6 @@
-const usersUrl = "//localhost:9000/users/";
-const catsUrl = "//localhost:9000/cats";
-const todosUrl = "//localhost:9000/todos/";
+const usersUrl = "http://api.boozang.com/users/";
+const catsUrl = "http://api.boozang.com/cats";
+const todosUrl = "http://api.boozang.com/todos/";
 
 export const UsersDb = () => {
   return (


### PR DESCRIPTION
## Summary
- Replace all hardcoded `localhost:9000` API URLs with `api.boozang.com` across 8 files
- Affects users, todos, and cats endpoints in forms, lists, and text components

## Test plan
- [ ] Verify API calls work against api.boozang.com
- [ ] Test form submissions (FormFill)
- [ ] Test todo list CRUD operations (AddTodo, SortedList, UnsortedList)
- [ ] Test cat shelter CRUD operations (AddCat, CatDetails, CatShelter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)